### PR TITLE
Small fixes to make this more friendly to terminal emacs users

### DIFF
--- a/spot4e.el
+++ b/spot4e.el
@@ -32,6 +32,7 @@
   (base64-encode-string spot4e-id-secret t))
 (defvar spot4e-redirect-uri (url-hexify-string "https://spotify.com"))
 (defvar spot4e-auth-url-full
+  (url-encode-url
   (concat
    "https://accounts.spotify.com/en/authorize"
    "?response_type=code&client_id=" spot4e-client-id
@@ -45,7 +46,7 @@
 		     "user-library-read "
 		     "user-follow-read "
 		     "user-read-recently-played")
-   "&show_dialog=" "true"))
+   "&show_dialog=" "true")))
 (defvar spot4e-token-url "https://accounts.spotify.com/api/token")
 (defvar spot4e-search-url "https://api.spotify.com/v1/search")
 

--- a/spot4e.el
+++ b/spot4e.el
@@ -108,6 +108,8 @@ alist of headers, and DATA is request body data as JSON."
 (defun spot4e-authorize ()
   "Obtain access_ and refresh_ tokens for user account."
   (interactive)
+  ;; Copy auth URL to kill ring (to respect terminal emacs users)
+  (kill-new spot4e-auth-url-full)
   (browse-url spot4e-auth-url-full)
   (setq spot4e-auth-code (read-string "Enter code from URL: "))
   (setq spot4e-tokens-alist


### PR DESCRIPTION
1) The auth URL should be put into the kill ring (suppose you don't have a workable default browser or you're going with EWW which just blows the hell up)

2) Speaking of URLs, the auth URL doesn't have the parameters URLencoded to make it one contiguous string.  Plays havoc when marking the URL to copy over to a "real" browser to auth.